### PR TITLE
fix(deps): upgrade vite to 5.4.21 to patch 4 CVEs

### DIFF
--- a/vim--base-app-template--react/package-lock.json
+++ b/vim--base-app-template--react/package-lock.json
@@ -31,7 +31,7 @@
         "postcss": "^8.4.41",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^5.4.1",
+        "vite": "^5.4.21",
         "wrangler": "4.13.0"
       }
     },
@@ -4129,9 +4129,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",

--- a/vim--base-app-template--react/package.json
+++ b/vim--base-app-template--react/package.json
@@ -35,7 +35,7 @@
     "postcss": "^8.4.41",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1",
+    "vite": "^5.4.21",
     "wrangler": "4.13.0"
   }
 }


### PR DESCRIPTION
## Summary

Upgrades `vite` from `5.4.14` to `5.4.21` in `vim--base-app-template--react` to address four CVEs, one of which is actively exploited in the wild.

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-31125 | Critical | Access control bypass — **actively exploited in the wild** |
| CVE-2025-30208 | High | File content disclosure |
| CVE-2025-31486 | High | File access bypass |
| CVE-2025-46565 | High | Path traversal |

## Changes

- `package.json`: bumped `vite` range from `^5.4.1` to `^5.4.21`
- `package-lock.json`: updated lock to resolve to `5.4.21`

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run dev` starts without errors